### PR TITLE
fix: trains do not depart if timefactor is 1x

### DIFF
--- a/simulation/trains.go
+++ b/simulation/trains.go
@@ -75,7 +75,7 @@ type Train struct {
 	ServiceCode    string         `json:"serviceCode"`
 	Speed          float64        `json:"speed"`
 	Status         TrainStatus    `json:"status"`
-	StoppedTime    int            `json:"stoppedTime"`
+	StoppedTime    float64        `json:"stoppedTime"`
 	TrainTypeCode  string         `json:"trainTypeCode"`
 	TrainHead      Position       `json:"trainHead"`
 
@@ -551,11 +551,11 @@ func (t *Train) updateStatus(timeElapsed time.Duration) {
 	}
 	// Train is already stopped at the place
 	if line.ScheduledDepartureTime.Sub(t.simulation.Options.CurrentTime) > 0 ||
-		t.StoppedTime < int(t.minStopTime/time.Second) ||
+		t.StoppedTime < float64(t.minStopTime) / float64(time.Second) ||
 		line.ScheduledDepartureTime.IsZero() {
 		// Conditions to depart are not met
 		t.Status = Stopped
-		t.StoppedTime += int(timeElapsed / time.Second)
+		t.StoppedTime += float64(timeElapsed) / float64(time.Second)
 		return
 	}
 	// Train departs


### PR DESCRIPTION
#44 

When timefactor = 1x, t.StoppedTime was always zero, so train did not depart.

t.StoppedTime type now float64 (was type int).

When 1x, t.StoppedTime increment value is 0.5 seconds, so rounded to zero.

