### PR TITLE
MaxSpeed: Use full length of train.  Implement Place MaxSpeed

### DIFF
--- a/plugins/trains/trains.go
+++ b/plugins/trains/trains.go
@@ -256,7 +256,7 @@ func calculatedSpeed(t *simulation.Train, targetDistance, targetSpeed float64) f
 
 // getMaxSpeed returns the maximum speed allowed for the train in its current position
 func getMaxSpeed(t *simulation.Train) float64 {
-	return math.Min(t.TrainType().MaxSpeed, t.TrainHead.TrackItem().MaxSpeed())
+	return math.Min(t.TrainType().MaxSpeed, t.MaxSpeedForTrainTrackItems())
 }
 
 var _ simulation.TrainsManager = StandardManager{}

--- a/simulation/track_items.go
+++ b/simulation/track_items.go
@@ -21,6 +21,7 @@ package simulation
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sync"
 )
 
@@ -273,10 +274,22 @@ func (t *trackStruct) PreviousItem() TrackItem {
 
 // MaxSpeed is the maximum allowed speed on this TrackItem in meters per second.
 func (t *trackStruct) MaxSpeed() float64 {
-	if t.TsMaxSpeed == 0 {
-		return t.simulation.Options.DefaultMaxSpeed
+
+	if t.PlaceCode == "" && t.TsMaxSpeed != 0 {
+		return t.TsMaxSpeed
 	}
-	return t.TsMaxSpeed
+	if t.PlaceCode != "" {
+		switch {
+		case t.Place().TsMaxSpeed == 0 && t.TsMaxSpeed != 0:
+			return t.TsMaxSpeed
+		case t.TsMaxSpeed == 0 && t.Place().TsMaxSpeed != 0:
+			return t.Place().TsMaxSpeed
+		case t.TsMaxSpeed != 0 && t.Place().TsMaxSpeed != 0:
+			return math.Min(t.TsMaxSpeed, t.Place().TsMaxSpeed)
+		}
+	}
+	// all other cases, default is the max speed of this sim
+	return t.simulation.Options.DefaultMaxSpeed
 }
 
 // RealLength is the length in meters that this TrackItem has in real life track length

--- a/simulation/track_items.go
+++ b/simulation/track_items.go
@@ -274,7 +274,6 @@ func (t *trackStruct) PreviousItem() TrackItem {
 
 // MaxSpeed is the maximum allowed speed on this TrackItem in meters per second.
 func (t *trackStruct) MaxSpeed() float64 {
-
 	if t.PlaceCode == "" && t.TsMaxSpeed != 0 {
 		return t.TsMaxSpeed
 	}

--- a/simulation/track_items.go
+++ b/simulation/track_items.go
@@ -21,7 +21,6 @@ package simulation
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"sync"
 )
 
@@ -274,21 +273,14 @@ func (t *trackStruct) PreviousItem() TrackItem {
 
 // MaxSpeed is the maximum allowed speed on this TrackItem in meters per second.
 func (t *trackStruct) MaxSpeed() float64 {
-	if t.PlaceCode == "" && t.TsMaxSpeed != 0 {
+	switch {
+	case t.TsMaxSpeed != 0:
 		return t.TsMaxSpeed
+	case t.PlaceCode != "" && t.Place().TsMaxSpeed != 0:
+		return t.Place().TsMaxSpeed
+	default:
+		return t.simulation.Options.DefaultMaxSpeed
 	}
-	if t.PlaceCode != "" {
-		switch {
-		case t.Place().TsMaxSpeed == 0 && t.TsMaxSpeed != 0:
-			return t.TsMaxSpeed
-		case t.TsMaxSpeed == 0 && t.Place().TsMaxSpeed != 0:
-			return t.Place().TsMaxSpeed
-		case t.TsMaxSpeed != 0 && t.Place().TsMaxSpeed != 0:
-			return math.Min(t.TsMaxSpeed, t.Place().TsMaxSpeed)
-		}
-	}
-	// all other cases, default is the max speed of this sim
-	return t.simulation.Options.DefaultMaxSpeed
 }
 
 // RealLength is the length in meters that this TrackItem has in real life track length

--- a/simulation/trains.go
+++ b/simulation/trains.go
@@ -130,6 +130,24 @@ func (t *Train) TrainTail() Position {
 	return t.TrainHead.Add(-t.TrainType().Length)
 }
 
+// TrainTrackItems returns a list of trackitems occupied by the train
+func (t *Train) trainTrackItems() []TrackItem {
+	return t.TrainTail().trackItemsToPosition(t.TrainHead)
+}
+
+// MaxSpeedForTrainTrackItems returns the lowest speed permitted for the
+//  train's current TrackItems.  Speed will be > 0
+func (t *Train) MaxSpeedForTrainTrackItems() float64 {
+
+	lowestSpeed := t.TrainType().MaxSpeed
+	for _, tti := range t.trainTrackItems() {
+		if tti.MaxSpeed() < lowestSpeed {
+			lowestSpeed = tti.MaxSpeed()
+		}
+	}
+	return math.Min(t.TrainType().MaxSpeed, lowestSpeed)
+}
+
 // MarshalJSON method for the train type
 func (t Train) MarshalJSON() ([]byte, error) {
 	type auxTrain Train

--- a/simulation/trains.go
+++ b/simulation/trains.go
@@ -138,7 +138,6 @@ func (t *Train) trainTrackItems() []TrackItem {
 // MaxSpeedForTrainTrackItems returns the lowest speed permitted for the
 //  train's current TrackItems.  Speed will be > 0
 func (t *Train) MaxSpeedForTrainTrackItems() float64 {
-
 	lowestSpeed := t.TrainType().MaxSpeed
 	for _, tti := range t.trainTrackItems() {
 		if tti.MaxSpeed() < lowestSpeed {


### PR DESCRIPTION
This patch implements two features:

1. When calculating MaxSpeed, the full length of the train is used, before only trainhead was used. 
2. If a TrackItem is linked to a Place, the maximum speed for the place is now also used.

The impact of this change is that trains do not accelerate until they are 100% clear of low speed areas (crossovers or station platform places for example).

Be aware that this patch now causes trains to operate very slowly in Liverpool Street, Wheler Street Junction and Bethnal Green TrackItems,  because these Places are low-speed.
[[  EDIT: No longer an issue in the latest push  ]]


Feedback welcome, I am not a go programmer !