### PR TITLE
Fix crash on simulation loading caused by missing signal actions list

### DIFF
--- a/simulation/trains.go
+++ b/simulation/trains.go
@@ -378,6 +378,17 @@ func (t *Train) updateSignalActions() {
 		}
 		t.lastSignal = nextSignal
 	}
+	
+	// make sure that at least one signal action is present now
+	// if not, accelerate to maximum speed
+	if len(t.signalActions) == 0 {
+		t.signalActions = []SignalAction{{
+			Target: ASAP,
+			Speed:  VeryHighSpeed,
+		}}
+		t.setActionIndex(0)
+		return
+	}
 
 	currentTime := t.simulation.Options.CurrentTime
 	if math.Abs(t.Speed-t.ApplicableAction().Speed) < 0.1 {


### PR DESCRIPTION
As title says, this fixes a crash when loading a previously saved simulation
It appears to happen as a result of the signal actions not being saved in the JSON file.

OT: You are probably no longer maintaining and continuing this project. I don't expect you to actually review and merge this.
As I am actually pretty impressed by the work you put into this project, and am sad to see this lie around unfinished, I have decided to fork and continue it, although starting off from 0.6. If you're interested: https://github.com/orwell96/ts2-fork